### PR TITLE
Add Custom Template example

### DIFF
--- a/src/examples/custom-template-example.tsx
+++ b/src/examples/custom-template-example.tsx
@@ -1,0 +1,49 @@
+import { createOptions, Select } from "@thisbeyond/solid-select";
+import { Show } from "solid-js";
+
+export const CustomTemplateExample = () => {
+  const props = createOptions(
+    [
+      { fruit: "apple", icon: "🍎", new: true },
+      { fruit: "banana", icon: "🍌", new: true },
+      { fruit: "pear", icon: "🍐", new: false },
+      { fruit: "pineapple", icon: "🍍", new: false },
+      { fruit: "kiwi", icon: "🥝", new: false },
+    ],
+    { key: "fruit", filterable: true }
+  );
+
+  const customFormat = (data: any, type: "option" | "value"): any =>
+    type === "option" ? (
+      <CustomOption
+        label={data.label}
+        new={data.value.new}
+        icon={data.value.icon}
+      />
+    ) : (
+      <CustomOption label={data.fruit} new={data.new} icon={data.icon} />
+    );
+
+  return <Select {...props} format={customFormat} />;
+};
+
+const CustomOption = (props: { label: string; icon: string; new: boolean }) => (
+  <>
+    <Show when={props.new}>
+      <span
+        style={{
+          background: "cornflowerblue",
+          color: "white",
+          "border-radius": "4px",
+          padding: "4px",
+          margin: "0 4px",
+          "font-size": "12px",
+        }}
+      >
+        NEW
+      </span>
+    </Show>
+    <span>{props.label}</span>
+    <span>{props.icon}</span>
+  </>
+);

--- a/src/pages/home.tsx
+++ b/src/pages/home.tsx
@@ -42,6 +42,8 @@ import { KitchenSinkExample } from "../examples/kitchen-sink-example";
 import kitchenSinkExampleString from "../examples/kitchen-sink-example?raw";
 import { GroupingExample } from "../examples/grouping-example";
 import groupingExampleString from "../examples/grouping-example?raw";
+import { CustomTemplateExample } from "../examples/custom-template-example";
+import customTemplateExampleString from "../examples/custom-template-example?raw";
 
 import "./home.css";
 
@@ -72,6 +74,7 @@ const Home = () => {
     "Static",
     "Reactive",
     "Reset",
+    "Custom Template",
     "Async Fetch",
     "Enable / Disable",
     "Filterable",
@@ -173,6 +176,14 @@ const Home = () => {
                   <ResetExample />
                 </ExampleDemo>
                 <ExampleCode code={resetExampleString} />
+              </Example>
+            </Match>
+            <Match when={example() === "Custom Template"}>
+              <Example>
+                <ExampleDemo>
+                  <CustomTemplateExample />
+                </ExampleDemo>
+                <ExampleCode code={customTemplateExampleString} />
               </Example>
             </Match>
             <Match when={example() === "Async Fetch"}>


### PR DESCRIPTION
Hello Martin :)

In my own app, I needed to customize the template used inside options in Solid Select by using the `format` prop. I was wondering if others might benefit from an example of this. This PR adds a new example to the site that shows how to do it.

![solid-select-custom-template](https://user-images.githubusercontent.com/9583103/222983516-98a8a5d4-3d42-4de5-9591-e5a8b006e71e.gif)

If you have any suggestions such as the name of this demo/feature, the order it appears in the list, or the style of the example code please let me know. Or feel free to make commits directly to the PR branch.

Cheers.